### PR TITLE
Create a Utils class

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -66,5 +66,6 @@ dependencies {
     testImplementation baseTestDependencies.androidxTestCore
     testImplementation baseTestDependencies.androidxTestRunner
     testImplementation baseTestDependencies.junit
+    testImplementation baseTestDependencies.robolectric
     testImplementation baseTestDependencies.mockito
 }

--- a/base/src/main/AndroidManifest.xml
+++ b/base/src/main/AndroidManifest.xml
@@ -1,1 +1,3 @@
-<manifest package="com.gart.base"/>
+<manifest package="com.gart.base" xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+</manifest>

--- a/base/src/main/java/com/gart/base/utils/Utils.kt
+++ b/base/src/main/java/com/gart/base/utils/Utils.kt
@@ -1,0 +1,18 @@
+package com.gart.base.utils
+
+import android.content.Context
+import android.net.ConnectivityManager
+
+abstract class Utils {
+
+    companion object {
+
+        fun isConnected(context: Context): Boolean {
+            val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            val networkInfo = connectivityManager.activeNetworkInfo
+
+            return networkInfo != null && networkInfo.isConnectedOrConnecting
+        }
+    }
+
+}

--- a/base/src/test/java/com/gart/base/utils/UtilsTest.kt
+++ b/base/src/test/java/com/gart/base/utils/UtilsTest.kt
@@ -1,0 +1,62 @@
+package com.gart.base.utils
+
+import android.app.Activity
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkInfo
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations.initMocks
+import org.mockito.Spy
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest= Config.NONE, sdk = [21])
+class UtilsTest {
+
+    @Spy
+    private val spyContext: Context = Robolectric.buildActivity(Activity::class.java).get()
+    @Mock
+    private lateinit var mockConnectivityManager: ConnectivityManager
+    @Mock
+    private lateinit var mockNetworkInfo: NetworkInfo
+
+    @Before
+    fun setUp() {
+        initMocks(this)
+    }
+
+    @Test
+    fun isConnected_should_return_false_if_networkInfo_is_null() {
+        `when`(spyContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager).thenReturn(mockConnectivityManager)
+        `when`(mockConnectivityManager.activeNetworkInfo).thenReturn(null)
+
+        assertFalse(Utils.isConnected(spyContext))
+    }
+
+    @Test
+    fun isConnected_should_return_false_if_networkInfo_isConnectedOrConnecting_returns_false() {
+        `when`(spyContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager).thenReturn(mockConnectivityManager)
+        `when`(mockConnectivityManager.activeNetworkInfo).thenReturn(mockNetworkInfo)
+        `when`(mockNetworkInfo.isConnectedOrConnecting).thenReturn(false)
+
+        assertFalse(Utils.isConnected(spyContext))
+    }
+
+    @Test
+    fun isConnected_should_return_true_if_networkInfo_is_not_null_and_isConnectedOrConnecting_returns_true() {
+        `when`(spyContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager).thenReturn(mockConnectivityManager)
+        `when`(mockConnectivityManager.activeNetworkInfo).thenReturn(mockNetworkInfo)
+        `when`(mockNetworkInfo.isConnectedOrConnecting).thenReturn(true)
+
+        assertTrue(Utils.isConnected(spyContext))
+    }
+
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -56,6 +56,7 @@ ext {
         junit:                  "androidx.test.ext:junit:${androidxJunitVersion}",
         androidxTestCore:       "androidx.test:core:${androidxTestCoreVersion}",
         androidxTestRunner:     "androidx.test:runner:${androidxTestRunnerVersion}",
+        robolectric:            "org.robolectric:robolectric:${robolectricVersion}",
         mockito:                "org.mockito:mockito-core:${mockitoVersion}"
     ]
 


### PR DESCRIPTION
The purpose of the utils class is to define a set of methods that are
common and often re-used in the app